### PR TITLE
Fix visual glitch on the bullet icon

### DIFF
--- a/styles/site.css
+++ b/styles/site.css
@@ -300,6 +300,7 @@ p.posted {
 div.news_item a.more {
         background:url("../assets/bullet.png") no-repeat 0 0px;
         padding-left: 20px;
+        padding-bottom: 1px;
 }
 div.news_item a:hover.more {
         background:url("../assets/bullet.png") no-repeat 0 -20px;


### PR DESCRIPTION
Allow the icon to show in full.

Before:
![image](https://user-images.githubusercontent.com/207112/27251113-6cd19d18-5348-11e7-93f3-fa4923ca681c.png)

After:
![image](https://user-images.githubusercontent.com/207112/27251117-7715c650-5348-11e7-82ab-e951d810dc12.png)
