### PR TITLE
Recommend RubyInstaller-2.4 version

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -6,11 +6,9 @@
     <ul id="navbar">
       <li {% if page.url contains "/about" %}id="active"{% endif %}><a href="{{ "/about" | relative_url }}">About</a></li>
       <li {% if page.url contains "/downloads" %}id="active"{% endif %}><a href="{{ "/downloads" | relative_url }}">Download</a></li>
-    <!--
-      <li><a href="http://wiki.github.com/oneclick/rubyinstaller">Knowledge Base</a></li>
-    -->
       <li><a href="http://github.com/oneclick/rubyinstaller2/wiki/">Help</a></li>
-      <li><a href="http://github.com/oneclick/rubyinstaller/wiki/How-to-Contribute/">Contribute</a></li>
     </ul>
   </div>
+  <!-- GitHub Ribbon taken from: https://github.com/blog/273-github-ribbons -->
+  <a href="https://github.com/oneclick/rubyinstaller2"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
 </div>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -9,7 +9,7 @@
     <!--
       <li><a href="http://wiki.github.com/oneclick/rubyinstaller">Knowledge Base</a></li>
     -->
-      <li><a href="http://github.com/oneclick/rubyinstaller/wiki/">Help</a></li>
+      <li><a href="http://github.com/oneclick/rubyinstaller2/wiki/">Help</a></li>
       <li><a href="http://github.com/oneclick/rubyinstaller/wiki/How-to-Contribute/">Contribute</a></li>
     </ul>
   </div>

--- a/downloads.md
+++ b/downloads.md
@@ -6,7 +6,7 @@ permalink: /downloads/
 ### Which version to download?
 
 If you don’t know what version to install and you’re getting started with Ruby,
-we recommend you use Ruby <b>2.2.X</b> installers. These provide a stable
+we recommend you use Ruby <b>2.4.X</b> installers. These provide a stable
 language and a extensive list of packages (gems) that are compatible and
 updated.
 
@@ -19,21 +19,21 @@ play with the language.
 
 ### Which Development Kit?
 
-Down this page, several and <em>different</em> versions of Development Kits (DevKit) are listed. Please download the right one for your version of Ruby:
+Starting with Ruby 2.4.0 we use the [MSYS2 toolkit](http://www.msys2.org) as our development kit.
+It is required to build native C/C++ extensions for Ruby and is necessary for [Ruby on Rails](http://rubyonrails.org/).
+Moreover it allows the download and usage of [hundreds of Open Source libraries](https://github.com/Alexpux/MINGW-packages) which Ruby gems can depend on.
+
+Down this page, several and <em>other</em> versions of Development Kits (DevKit) are listed.
+Please download the right one for your version of Ruby:
 
 * Ruby 2.4.0 and newer: The MSYS2 DevKit is downloaded as the last step of the installation.
+  It can be installed later per `ridk install` command.
 * Ruby 2.0.0 to 2.3.x (32bits): *mingw64-32-4.7.2*
 * Ruby 2.0.0 to 2.3.x (64bits): *mingw64-64-4.7.2*
 
-The [RubyInstaller Development Kit (DevKit)](http://github.com/oneclick/rubyinstaller/wiki/Development-Kit) is
-a MSYS/MinGW based toolkit than enables you to build many of the native C/C++ extensions available for Ruby.
-Starting with Ruby 2.4.0 it is replaced by the [MSYS2 toolkit](http://www.msys2.org).
-
 ### Speed and Compatibility
 
-RubyInstaller is compiled with MinGW which offers improved speed and better
-RubyGem compatibility, including support for many more native C-based extensions such as <a href="http://github.com/ffi/ffi">Ruby FFI</a>, <a href="http://nokogiri.org/">Nokogiri</a>,
-<a href="http://www.fxruby.org/">FXRuby</a> and <a href="http://github.com/oneclick/rubyinstaller/wiki/Gem-List">many others</a>.
+RubyInstaller is compiled with MinGW-w64 which offers improved speed and better RubyGem compatibility.
 
 ### Convenience
 
@@ -43,10 +43,10 @@ If you would like to use the 7-Zip archived versions or the Ruby documentation, 
 ### Documentation
 
 The Ruby core and standard library documentation is part of the installation.
-As an added convenience for Windows users, we’ve made available the Ruby Core and Standard Library documentation
-in Compiled HTML Help (CHM) format.
+We also recommend the [online documentation](https://ruby-doc.org/) or HTML version downloadable [from ruby-doc.org](https://ruby-doc.org/downloads/).
+
+As an added convenience for Windows users, we’ve made available the Ruby Core and Standard Library documentation in Compiled HTML Help (CHM) format.
 It can be downloaded separately for older Ruby versions.
-For newer Ruby versions we recommend the [online documentation](https://ruby-doc.org/) or HTML version downloadable [from ruby-doc.org](https://ruby-doc.org/downloads/).
 
 ### Support
 


### PR DESCRIPTION
IMHO support of gems for RubyInstaller-2.4 is now at a level similar to previous versions. Some gems still don't support it, but other gems don't work with previous RI versions but with RI2.4. That makes it simple enough to use and, given that the previous releases don't get updates anymore, better suited than RubyInstaller-2.2 for new users. Maybe this view is biased, because I often push the gems that I use, to make them compatible.

This also changes the links to the new rubyinstaller2 repository, where not yet done. However there is the big ["+ Contribute" button at the bottom of the page](https://github.com/oneclick/rubyinstaller.org-website/blob/master/_layouts/home.html#L31-L34), which I don't know how to link to. The content of the wiki page seems mostly outdated for me and I doubt, that it will be the way to convince users to contribute. Should we remove this link? Or where should it link to?
