### PR TITLE
Add specific instructions on how to install devkit

### DIFF
--- a/downloads.md
+++ b/downloads.md
@@ -28,8 +28,8 @@ Please download the right one for your version of Ruby:
 
 * Ruby 2.4.0 and newer: The MSYS2 DevKit is downloaded as the last step of the installation.
   It can be installed later per `ridk install` command.
-* Ruby 2.0.0 to 2.3.x (32bits): *mingw64-32-4.7.2*
-* Ruby 2.0.0 to 2.3.x (64bits): *mingw64-64-4.7.2*
+* Ruby 2.0.0 to 2.3.x (32bits): *mingw64-32-4.7.2* and run `devkitvars.bat` to add the devkit to your path
+* Ruby 2.0.0 to 2.3.x (64bits): *mingw64-64-4.7.2* and run `devkitvars.bat` to add the devkit to your path
 
 ### Speed and Compatibility
 


### PR DESCRIPTION
It's not clear when downloading the devkit, what your next steps should be - just extracting it to a folder (the default) is not enough. You also have to run `devkitvars.bat` to add the location of the devkit to your path.

This change adds instructions on the Download page to help new users out.