### PR TITLE
Fix anchor tags for more info on download links

### DIFF
--- a/_includes/downloadlinks.html
+++ b/_includes/downloadlinks.html
@@ -2,14 +2,17 @@
   <li class="{{ dl.filetype }}">
     <a class="downloadlink" href="{{ dl.href }}">{{ dl.name }}</a>
     {% if dl.gpgsign or dl.sha256 %}
-      <a class="downloadinfo">🢆</a>
+      <a class="downloadinfo" title="Show / hide details"></a>
       <ul class="downloadinfo">
         {% if dl.gpgsign %}
           <li>download <a href="{{ dl.gpgsign }}">GPG signature</a></li>
         {% endif %}
         {% if dl.sha256 %}
           <li>
-            SHA256: <input class="js-copytextinput buttonbox" value="{{ dl.sha256 }}"/><button class="js-copybtn buttonbox" style="vertical-align:top;"><img src="{{ "/assets/copy_clipboard.svg" | relative_url }}"></button>
+            SHA256: <input class="js-copytextinput buttonbox" value="{{ dl.sha256 }}"/>
+            <button class="js-copybtn buttonbox" style="vertical-align:top;" title="Copy to clipboard">
+              <img src="{{ "/assets/copy_clipboard.svg" | relative_url }}">
+            </button>
           </li>
         {% endif %}
       </ul>

--- a/assets/application.js
+++ b/assets/application.js
@@ -6,7 +6,8 @@ $(function() {
     document.execCommand("copy");
   });
 
-  $("a.downloadinfo, a.downloadlink").click(function () {
+  $("a.downloadinfo").click(function () {
+    $(this).toggleClass("active");
     $(this).nextAll("ul.downloadinfo").toggle(500);
   });
 });

--- a/styles/site.css
+++ b/styles/site.css
@@ -417,9 +417,16 @@ li.rubyinstaller7z, li.rubychm7z { list-style-image:url("../assets/sevenz_16x16.
 li.chksum { list-style-image:url("../assets/chksum_16x16.png"); list-style-position:inside; }
 li.devkitsfx { list-style-image:url("../assets/sfx_24x19.png"); list-style-position:inside; }
 
-a.downloadinfo {
-  padding-left: 10px;
+a.downloadlink {
+  display: inline-block;
+  min-width: 100px;
 }
+
+a.downloadinfo { padding-left: 10px; }
+a.downloadinfo:after { content: "\2261"; }
+a.downloadinfo.active:after { content: "\2297"; vertical-align: text-bottom; }
+a.downloadinfo:hover { text-decoration: none; }
+
 ul.downloadinfo {
   list-style-image:none;
   display: none;


### PR DESCRIPTION
Resolves #6 

- adds unicode symbols for light-weight cross-platform compatibility
- adds anchor-titles to render tooltips on hovering over details' links

![localhost_4000_downloads_](https://user-images.githubusercontent.com/12479464/34576443-f1e49966-f1a3-11e7-8702-fa233396223b.png)
