### PR TITLE
add news about rvm-windows 1.0.0 release

### DIFF
--- a/_posts/2024-12-11-rvm-windows-1.0.0-released.md
+++ b/_posts/2024-12-11-rvm-windows-1.0.0-released.md
@@ -1,0 +1,17 @@
+---
+layout: post
+title:  "Ruby Version Manager 4 Windows 1.0.0 released"
+author: Matthäus J. N. Beyrle
+---
+The final version 1.0.0 of the Ruby Version Manager for Windows (rvm-windows) has been released.
+
+It is inspired by the [rvm.io](https://rvm.io) project for Unix systems and provides a similar user experience for Windows users by providing a compatible command line interface.
+
+The Ruby Version Manager for Windows is a command line tool that allows you to easily install, manage, and work with multiple Ruby environments from interpreters to sets of gems.
+It even works with the classic Windows command line and Powershell.
+
+It is based on the x64 binaries provided by the [RubyInstaller project](https://rubyinstaller.org/).
+
+Its goal is not to 100% reimplement all features of rvm.io, but the most important and common ones by preserving most of the same command line interface. Some special Windows related stuff is added as well.
+
+More information can be found on the [rvm-windows Github repository](https://github.com/magynhard/rvm-windows/).


### PR DESCRIPTION
As announced before on the installer repo ...
https://github.com/oneclick/rubyinstaller2/issues/378

Was not sure, if you are interested to share the news about the 1.0.0. release, as it is based on RubyInstaller.

I'm open for changes in the text and do not need to be the author, if that is not the way you want to publish this news.